### PR TITLE
fix conflict with cmake/cmake-filesystem

### DIFF
--- a/cmake/Pack.cmake
+++ b/cmake/Pack.cmake
@@ -22,6 +22,8 @@ set(CPACK_RPM_PACKAGE_RELEASE ${PACKAGE_RELEASE})
 message(STATUS "CPACK_RPM_PACKAGE_RELEASE is ${CPACK_RPM_PACKAGE_RELEASE}")
 # RPM doesn't support this changelog format
 # set(CPACK_RPM_CHANGELOG_FILE ${PROJECT_SOURCE_DIR}/CHANGELOG.md)
+# The directory below conflicts with cmake-filesystem/cmake-2.8
+list(APPEND CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/lib64/cmake")
 
 set(CPACK_DEBIAN_FILE_NAME          DEB-DEFAULT)
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "OceanBase")


### PR DESCRIPTION
<!--
Thank you for contributing to OceanBase! 
Please feel free to ping the maintainers for the review!
-->

## Summary
<!-- 
Please clearly and concisely describe the purpose of this pull request.
If this pull request resolves an issue, please link it via "close #xxx" or "fix #xxx".
-->

Error when installing by yum:
![image](https://github.com/user-attachments/assets/b2735166-8e0a-4f90-921c-c000c88de25c)


## Solution Description
<!-- Please clearly and concisely describe your solution. -->

append "/usr/lib64/cmake" to list CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION.
refer to https://github.com/google/flatbuffers/issues/5947